### PR TITLE
Every callable callback are now supported as route handler

### DIFF
--- a/src/Jarvis.php
+++ b/src/Jarvis.php
@@ -125,6 +125,10 @@ final class Jarvis extends Container
                 $this->masterBroadcast(JarvisEvents::CONTROLLER_EVENT,  $event);
 
                 $response = call_user_func_array($event->getCallback(), $event->getArguments());
+
+                if (is_string($response)) {
+                    $response = new Response($response);
+                }
             } elseif (Dispatcher::NOT_FOUND === $routeInfo[0] || Dispatcher::METHOD_NOT_ALLOWED === $routeInfo[0]) {
                 $response = new Response(null, Dispatcher::NOT_FOUND === $routeInfo[0]
                     ? Response::HTTP_NOT_FOUND

--- a/src/Jarvis.php
+++ b/src/Jarvis.php
@@ -119,13 +119,12 @@ final class Jarvis extends Container
 
             $routeInfo = $this->router->match($request->getMethod(), $request->getPathInfo());
             if (Dispatcher::FOUND === $routeInfo[0]) {
-                list($controller, $action) = $this->callback_resolver->resolve($routeInfo[1]);
-                $event = new ControllerEvent($controller, $action, $routeInfo[2]);
+                $callback = $this->callback_resolver->resolve($routeInfo[1]);
 
+                $event = new ControllerEvent($callback, $routeInfo[2]);
                 $this->masterBroadcast(JarvisEvents::CONTROLLER_EVENT,  $event);
 
-                $response = call_user_func_array([$event->controller, $event->action], $event->arguments);
-
+                $response = call_user_func_array($event->getCallback(), $event->getArguments());
             } elseif (Dispatcher::NOT_FOUND === $routeInfo[0] || Dispatcher::METHOD_NOT_ALLOWED === $routeInfo[0]) {
                 $response = new Response(null, Dispatcher::NOT_FOUND === $routeInfo[0]
                     ? Response::HTTP_NOT_FOUND

--- a/src/Skill/Core/CallbackResolver.php
+++ b/src/Skill/Core/CallbackResolver.php
@@ -25,6 +25,10 @@ class CallbackResolver
             }
         }
 
+        if (!is_callable($callback)) {
+            throw new \InvalidArgumentException('Provided callback is not callable.');
+        }
+
         return $callback;
     }
 }

--- a/src/Skill/EventBroadcaster/ControllerEvent.php
+++ b/src/Skill/EventBroadcaster/ControllerEvent.php
@@ -7,14 +7,77 @@ namespace Jarvis\Skill\EventBroadcaster;
  */
 class ControllerEvent extends SimpleEvent
 {
-    public $controller;
-    public $action;
-    public $arguments;
+    private $callback;
+    private $arguments;
 
-    public function __construct($controller, $action, $arguments)
+    public function __construct($callback, array $arguments = [])
     {
-        $this->controller = $controller;
-        $this->action = $action;
+        $this->callback = $this->validateCallback($callback);
         $this->arguments = $arguments;
+    }
+
+    /**
+     * @codeCoverageIgnore
+     *
+     * @return mixed
+     */
+    public function getCallback()
+    {
+        return $this->callback;
+    }
+
+    /**
+     * Set new callback to ControllerEvent. It must be callable.
+     *
+     * @param  mixed $callback The new callback to set
+     * @return self
+     * @throws \InvalidArgumentException if passed callback is not callable
+     */
+    public function setCallback($callback)
+    {
+        $this->callback = $this->validateCallback($callback);
+
+        return $this;
+    }
+
+    /**
+     * @codeCoverageIgnore
+     *
+     * @return mixed
+     */
+    public function getArguments()
+    {
+        return $this->arguments;
+    }
+
+    /**
+     * @codeCoverageIgnore
+     *
+     * Sets new list of arguments to ControllerEvent.
+     *
+     * @param  array $arguments The new arguments to set, default: empty array ([])
+     * @return self
+     */
+    public function setArguments(array $arguments = [])
+    {
+        $this->arguments = $arguments;
+
+        return $this;
+    }
+
+    /**
+     * Validates provided callback and throws exception if it is not callable.
+     *
+     * @param  mixed $callback The callback to validate
+     * @return mixed
+     * @throws \InvalidArgumentException if passed callback is not callable
+     */
+    public function validateCallback($callback)
+    {
+        if (!is_callable($callback)) {
+            throw new \InvalidArgumentException('Provided callback is not callable.');
+        }
+
+        return $callback;
     }
 }

--- a/tests/CallbackResolverTest.php
+++ b/tests/CallbackResolverTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Jarvis\Tests;
+
+use Jarvis\Jarvis;
+use Jarvis\Skill\DependencyInjection\Reference;
+
+/**
+ * @author Eric Chau <eriic.chau@gmail.com>
+ */
+class CallbackResolver extends \PHPUnit_Framework_TestCase
+{
+    public function testReferenceIsReplacedByValueFromController()
+    {
+        $jarvis = new Jarvis();
+
+        $jarvis['fake_controller'] = function () {
+            return new FakeController();
+        };
+
+        $fakeController = $jarvis['fake_controller'];
+
+        $callback = [new Reference('fake_controller'), 'randomAction'];
+
+        $callback = $jarvis->callback_resolver->resolve($callback);
+
+        $this->assertNotInstanceOf(Reference::class, $callback[0]);
+        $this->assertSame($fakeController, $callback[0]);
+    }
+
+    public function testResolveAcceptAnyCallableCallback()
+    {
+        $jarvis = new Jarvis();
+
+        $jarvis->callback_resolver->resolve([new FakeController(), 'randomAction']);
+        $jarvis->callback_resolver->resolve(['DateTime', 'createFromFormat']);
+        $jarvis->callback_resolver->resolve('rand');
+        $jarvis->callback_resolver->resolve(function () {});
+
+        $this->assertTrue(true);
+    }
+
+    /**
+     * @expectedException        \InvalidArgumentException
+     * @expectedExceptionMessage Provided callback is not callable.
+     */
+    public function testResolveRaisesExceptionOnInvalidCallback()
+    {
+        $jarvis = new Jarvis();
+
+        $jarvis->callback_resolver->resolve([new FakeController(), 'unknownAction']);
+    }
+}

--- a/tests/ControllerEventTest.php
+++ b/tests/ControllerEventTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Jarvis\Tests;
+
+use Jarvis\Skill\EventBroadcaster\ControllerEvent;
+
+/**
+ * @author Eric Chau <eriic.chau@gmail.com>
+ */
+class ControllerEventTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @expectedException        \InvalidArgumentException
+     * @expectedExceptionMessage Provided callback is not callable.
+     */
+    public function testSetInvalidCallbackRaiseException()
+    {
+        $event = new ControllerEvent(function () {});
+
+        $this->assertSame($event, $event->setCallback('rand'));
+        $event->setCallback('foobar');
+    }
+}

--- a/tests/JarvisTest.php
+++ b/tests/JarvisTest.php
@@ -183,4 +183,20 @@ class JarvisTest extends \PHPUnit_Framework_TestCase
 
         $jarvis->foo = 'bar';
     }
+
+    public function testAnalyzeWillConvertToSymfonyResponseIfRouteCallbackReturnString()
+    {
+        $jarvis = new Jarvis();
+
+        $str = 'hello world';
+
+        $jarvis->router->addRoute('get', '/', function () use ($str) {
+            return $str;
+        });
+
+        $result = $jarvis->analyze();
+
+        $this->assertInstanceOf(Response::class, $result);
+        $this->assertSame($str, $result->getContent());
+    }
 }


### PR DESCRIPTION
@mickaelandrieu I integrated your request into Jarvis ;)

This PR introduce the support of any callable callback as route handler. The syntax below is now working:

``` php
use Jarvis\Jarvis;

$jarvis = new Jarvis();

$jarvis->router->addRoute('get', '/', function() {
    return 'hello world';
});
```

This PR also introduced a new mechanism, if the route handler return a string it will be automatically be converted into `Symfony Response` object.

This PR also resolves #9 and #11.
