### PR TITLE
Added receiver priority feature

### DIFF
--- a/src/Skill/DependencyInjection/ContainerProvider.php
+++ b/src/Skill/DependencyInjection/ContainerProvider.php
@@ -61,7 +61,7 @@ class ContainerProvider implements ContainerProviderInterface
         $jarvis->addReceiver(JarvisEvents::EXCEPTION_EVENT, [
             new Reference('jarvis.exception_receiver'),
             'onExceptionEvent',
-        ]);
+        ], Jarvis::RECEIVER_LOW_PRIORITY);
 
         $jarvis->lock(['request', 'router', 'callback_resolver', 'jarvis.exception_receiver']);
     }

--- a/tests/FakeReceiver.php
+++ b/tests/FakeReceiver.php
@@ -13,6 +13,7 @@ class FakeReceiver
     public $analyzeEvent;
     public $controllerEvent;
     public $responseEvent;
+    public $microTimestamp;
 
     public function onEventBroadcast($event)
     {
@@ -44,5 +45,10 @@ class FakeReceiver
     {
         $this->responseEvent = $event;
         $event->getResponse()->setContent('bar');
+    }
+
+    public function saveMicroTimestamp($event)
+    {
+        $this->microTimestamp = microtime(true);
     }
 }

--- a/tests/JarvisBroadcasterTest.php
+++ b/tests/JarvisBroadcasterTest.php
@@ -111,4 +111,28 @@ class JarvisBroadcasterTest extends \PHPUnit_Framework_TestCase
         $jarvis = new Jarvis();
         $jarvis->broadcast(JarvisEvents::EXCEPTION_EVENT);
     }
+
+    public function testEventReceiversPriorities()
+    {
+        $jarvis = new Jarvis();
+
+        $eventName = 'receiver_priority_test';
+
+        $lowPriorityReceiver = new FakeReceiver();
+        $normalPriorityReceiver = new FakeReceiver();
+        $highPriorityReceiver = new FakeReceiver();
+
+        $this->assertNull($lowPriorityReceiver->microTimestamp);
+        $this->assertNull($normalPriorityReceiver->microTimestamp);
+        $this->assertNull($highPriorityReceiver->microTimestamp);
+
+        $jarvis->addReceiver($eventName, [$lowPriorityReceiver, 'saveMicroTimestamp'], Jarvis::RECEIVER_LOW_PRIORITY);
+        $jarvis->addReceiver($eventName, [$normalPriorityReceiver, 'saveMicroTimestamp'], Jarvis::RECEIVER_NORMAL_PRIORITY);
+        $jarvis->addReceiver($eventName, [$highPriorityReceiver, 'saveMicroTimestamp'], Jarvis::RECEIVER_HIGH_PRIORITY);
+
+        $jarvis->broadcast($eventName);
+
+        $this->assertTrue($normalPriorityReceiver->microTimestamp < $lowPriorityReceiver->microTimestamp);
+        $this->assertTrue($highPriorityReceiver->microTimestamp < $normalPriorityReceiver->microTimestamp);
+    }
 }


### PR DESCRIPTION
`Jarvis::addReceiver()` now accepts a third parameter to define the receiver priority. So it also introduces 3 new contants into Jarvis:
- `Jarvis::RECEIVER_HIGH_PRIORITY`
- `Jarvis::RECEIVER_NORMAL_PRIORITY`
- `Jarvis::RECEIVER_LOW_PRIORITY`
