### PR TITLE
Simplified Jarvis constants names

### DIFF
--- a/src/Jarvis.php
+++ b/src/Jarvis.php
@@ -22,11 +22,11 @@ use Symfony\Component\HttpFoundation\Response;
  *
  * @author Eric Chau <eriic.chau@gmail.com>
  */
-final class Jarvis extends Container
+class Jarvis extends Container
 {
-    const JARVIS_DEFAULT_DEBUG = false;
-    const JARVIS_CONTAINER_PROVIDER_FQCN = ContainerProvider::class;
-    const JARVIS_DEFAULT_SCOPE = 'default';
+    const DEFAULT_DEBUG = false;
+    const CONTAINER_PROVIDER_FQCN = ContainerProvider::class;
+    const DEFAULT_SCOPE = 'default';
 
     const RECEIVER_HIGH_PRIORITY = 2;
     const RECEIVER_NORMAL_PRIORITY = 1;
@@ -54,14 +54,14 @@ final class Jarvis extends Container
         $this['settings'] = new ParameterBag($settings);
         $this->lock('settings');
 
-        $this['debug'] = $this->settings->getBoolean('debug', self::JARVIS_DEFAULT_DEBUG);
+        $this['debug'] = $this->settings->getBoolean('debug', self::DEFAULT_DEBUG);
         $this->lock('debug');
 
         if (!$this->settings->has('container_provider')) {
-            $this->settings->set('container_provider', [self::JARVIS_CONTAINER_PROVIDER_FQCN]);
+            $this->settings->set('container_provider', [self::CONTAINER_PROVIDER_FQCN]);
         } else {
             $containerProvider = $this->settings->get('container_provider');
-            array_unshift($containerProvider, self::JARVIS_CONTAINER_PROVIDER_FQCN);
+            array_unshift($containerProvider, self::CONTAINER_PROVIDER_FQCN);
             $this->settings->set('container_provider', $containerProvider);
         }
 

--- a/src/Jarvis.php
+++ b/src/Jarvis.php
@@ -54,14 +54,14 @@ class Jarvis extends Container
         $this['settings'] = new ParameterBag($settings);
         $this->lock('settings');
 
-        $this['debug'] = $this->settings->getBoolean('debug', self::DEFAULT_DEBUG);
+        $this['debug'] = $this->settings->getBoolean('debug', static::DEFAULT_DEBUG);
         $this->lock('debug');
 
         if (!$this->settings->has('container_provider')) {
-            $this->settings->set('container_provider', [self::CONTAINER_PROVIDER_FQCN]);
+            $this->settings->set('container_provider', [static::CONTAINER_PROVIDER_FQCN]);
         } else {
             $containerProvider = $this->settings->get('container_provider');
-            array_unshift($containerProvider, self::CONTAINER_PROVIDER_FQCN);
+            array_unshift($containerProvider, static::CONTAINER_PROVIDER_FQCN);
             $this->settings->set('container_provider', $containerProvider);
         }
 

--- a/src/Skill/Core/ScopeManager.php
+++ b/src/Skill/Core/ScopeManager.php
@@ -10,13 +10,13 @@ use Jarvis\Jarvis;
 class ScopeManager
 {
     private $scopes = [
-        Jarvis::JARVIS_DEFAULT_SCOPE => true,
+        Jarvis::DEFAULT_SCOPE => true,
     ];
 
     public function disable($names)
     {
         foreach ((array) $names as $name) {
-            if (Jarvis::JARVIS_DEFAULT_SCOPE === $name) {
+            if (Jarvis::DEFAULT_SCOPE === $name) {
                 continue;
             }
 

--- a/src/Skill/Routing/Router.php
+++ b/src/Skill/Routing/Router.php
@@ -28,7 +28,7 @@ class Router extends Dispatcher
      * Alias to Router's route collector ::addRoute method.
      * @see RouteCollector::addRoute
      */
-    public function addRoute($httpMethod, $route, $handler, $scope = Jarvis::JARVIS_DEFAULT_SCOPE)
+    public function addRoute($httpMethod, $route, $handler, $scope = Jarvis::DEFAULT_SCOPE)
     {
         if (!isset($this->rawRoutes[$scope])) {
             $this->rawRoutes[$scope] = [];

--- a/tests/ScopeManagerTest.php
+++ b/tests/ScopeManagerTest.php
@@ -13,10 +13,10 @@ class ScopeManagerTest extends \PHPUnit_Framework_TestCase
         $scopeManager = new ScopeManager();
 
         $this->assertCount(1, $scopeManager->getAll());
-        $this->assertTrue($scopeManager->isEnabled(Jarvis::JARVIS_DEFAULT_SCOPE));
+        $this->assertTrue($scopeManager->isEnabled(Jarvis::DEFAULT_SCOPE));
 
-        $scopeManager->disable(Jarvis::JARVIS_DEFAULT_SCOPE);
-        $this->assertTrue($scopeManager->isEnabled(Jarvis::JARVIS_DEFAULT_SCOPE));
+        $scopeManager->disable(Jarvis::DEFAULT_SCOPE);
+        $this->assertTrue($scopeManager->isEnabled(Jarvis::DEFAULT_SCOPE));
     }
 
     public function testEnableAndDisableScope()


### PR DESCRIPTION
With the removal of the `final` keyword on `Jarvis\Jarvis` class declaration, it is now extendable. This PR also simplified Jarvis own contants names to be more concise.
