### PR TITLE
added Jarvis::hydrate()

### DIFF
--- a/src/Jarvis.php
+++ b/src/Jarvis.php
@@ -64,14 +64,7 @@ class Jarvis extends Container
         }
 
         foreach ($this->settings->get('container_provider') as $classname) {
-            if (!is_subclass_of($classname, ContainerProviderInterface::class)) {
-                throw new \InvalidArgumentException(sprintf(
-                    'Expect every container provider to implement %s.',
-                    ContainerProviderInterface::class
-                ));
-            }
-
-            $classname::hydrate($this);
+            $this->hydrate($classname);
         }
     }
 
@@ -186,6 +179,21 @@ class Jarvis extends Container
                 }
             }
         }
+
+        return $this;
+    }
+
+    public function hydrate($classname)
+    {
+        if (!is_subclass_of($classname, ContainerProviderInterface::class)) {
+            throw new \InvalidArgumentException(sprintf(
+                'Expect every container provider to implement %s and %s does not.',
+                ContainerProviderInterface::class,
+                $classname
+            ));
+        }
+
+        $classname::hydrate($this);
 
         return $this;
     }


### PR DESCRIPTION
Previsouly, hydration of Jarvis container was done in its constructor. As we offer the posibility to extend Jarvis with the removal of  `final`, it's also relevant to extract injection of service and parameters from its contructor to a standalone public method: `Jarvis\Jarvis::hydrate()`
