### PR TITLE
updated ContainerProviderInterface and hydrate() is not longer static

### DIFF
--- a/src/Jarvis.php
+++ b/src/Jarvis.php
@@ -43,8 +43,6 @@ class Jarvis extends Container
      *   - container_provider (type: string|array): fqcn of your container provider
      *
      * @param  array $settings Your own settings to modify Jarvis behavior
-     * @throws \InvalidArgumentException if provided container provider class doesn't
-     *                                   implement ContainerProviderInterface
      */
     public function __construct(array $settings = [])
     {
@@ -65,7 +63,7 @@ class Jarvis extends Container
         }
 
         foreach ($this->settings->get('container_provider') as $classname) {
-            $this->hydrate($classname);
+            $this->hydrate(new $classname());
         }
     }
 
@@ -206,20 +204,12 @@ class Jarvis extends Container
     }
 
     /**
-     * @param  string $classname
+     * @param  string $provider
      * @return self
      */
-    public function hydrate($classname)
+    public function hydrate(ContainerProviderInterface $provider)
     {
-        if (!is_subclass_of($classname, ContainerProviderInterface::class)) {
-            throw new \InvalidArgumentException(sprintf(
-                'Expect every container provider to implement %s and %s does not.',
-                ContainerProviderInterface::class,
-                $classname
-            ));
-        }
-
-        $classname::hydrate($this);
+        call_user_func([$provider, 'hydrate'], $this);
 
         return $this;
     }

--- a/src/Skill/DependencyInjection/ContainerProvider.php
+++ b/src/Skill/DependencyInjection/ContainerProvider.php
@@ -22,7 +22,7 @@ class ContainerProvider implements ContainerProviderInterface
     /**
      * {@inheritdoc}
      */
-    public static function hydrate(Jarvis $jarvis)
+    public function hydrate(Jarvis $jarvis)
     {
         $jarvis['request'] = function($jarvis) {
             if (
@@ -55,10 +55,10 @@ class ContainerProvider implements ContainerProviderInterface
 
         $jarvis->lock(['request', 'router', 'callback_resolver']);
 
-        self::registerReceivers($jarvis);
+        $this->registerReceivers($jarvis);
     }
 
-    private static function registerReceivers(Jarvis $jarvis)
+    private function registerReceivers(Jarvis $jarvis)
     {
         $jarvis->addReceiver(JarvisEvents::EXCEPTION_EVENT, function(ExceptionEvent $event) {
             $response = new Response($event->getException()->getMessage(), Response::HTTP_INTERNAL_SERVER_ERROR);

--- a/src/Skill/DependencyInjection/ContainerProviderInterface.php
+++ b/src/Skill/DependencyInjection/ContainerProviderInterface.php
@@ -17,5 +17,5 @@ interface ContainerProviderInterface
      *
      * @param  Jarvis $container The container to hydrate
      */
-    public static function hydrate(Jarvis $container);
+    public function hydrate(Jarvis $container);
 }

--- a/tests/JarvisTest.php
+++ b/tests/JarvisTest.php
@@ -118,19 +118,6 @@ class JarvisTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('bar', $jarvis['settings']->get('foo'));
     }
 
-    /**
-     * @expectedException        InvalidArgumentException
-     * @expectedExceptionMessage Expect every container provider to implement Jarvis\Skill\DependencyInjection\ContainerProviderInterface
-     */
-    public function testInvalidContainerProvider()
-    {
-        new Jarvis([
-            'container_provider' => [
-                'stdClass',
-            ],
-        ]);
-    }
-
     public function testOverrideRequestClassname()
     {
         $jarvis = new Jarvis(['request_fqcn' => FakeRequest::class]);


### PR DESCRIPTION
Updated `Jarvis\Skill\DependencyInjection\ContainerProviderInterface::hydrate()` so it is no longer a static method. This change is done so `Jarvis\Jarvis::hydrate()` argument can be type hinted. Also, IMO it's better to let Php engine throws an error than throwing exception by ourself.
