### PR TITLE
Added permanent event feature

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,10 +5,10 @@
     "require": {
         "php": ">=7.0.0",
         "nikic/fast-route": "0.*",
-        "symfony/http-foundation": "3.0.*"
+        "symfony/http-foundation": "~3.0.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "5.1.*",
+        "phpunit/phpunit": "~5.1.0",
         "codeclimate/php-test-reporter": "dev-master"
     },
     "autoload": {

--- a/src/Skill/EventBroadcaster/PermanentEvent.php
+++ b/src/Skill/EventBroadcaster/PermanentEvent.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Jarvis\Skill\EventBroadcaster;
+
+/**
+ * @author Eric Chau <eriic.chau@gmail.com>
+ */
+class PermanentEvent extends SimpleEvent implements PermanentEventInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function isPermanent() : bool
+    {
+        return true;
+    }
+}

--- a/src/Skill/EventBroadcaster/PermanentEventInterface.php
+++ b/src/Skill/EventBroadcaster/PermanentEventInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Jarvis\Skill\EventBroadcaster;
+
+/**
+ * Permanent event is an event that can be invoked on new receiver even if the
+ * event was already dispatched.
+ *
+ * @author Eric Chau <eriic.chau@gmail.com>
+ */
+interface PermanentEventInterface extends EventInterface
+{
+    /**
+     * @return boolean
+     */
+    public function isPermanent() : bool;
+}

--- a/tests/JarvisBroadcasterTest.php
+++ b/tests/JarvisBroadcasterTest.php
@@ -8,6 +8,7 @@ use Jarvis\Skill\EventBroadcaster\AnalyzeEvent;
 use Jarvis\Skill\EventBroadcaster\ControllerEvent;
 use Jarvis\Skill\EventBroadcaster\EventInterface;
 use Jarvis\Skill\EventBroadcaster\JarvisEvents;
+use Jarvis\Skill\EventBroadcaster\PermanentEvent;
 use Jarvis\Skill\EventBroadcaster\SimpleEvent;
 use Jarvis\Skill\EventBroadcaster\ResponseEvent;
 use Symfony\Component\HttpFoundation\Request;
@@ -138,5 +139,26 @@ class JarvisBroadcasterTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue($normalPriorityReceiver->microTimestamp < $lowPriorityReceiver->microTimestamp);
         $this->assertTrue($highPriorityReceiver->microTimestamp < $normalPriorityReceiver->microTimestamp);
+    }
+
+    public function testPermanentEvent()
+    {
+        $jarvis = new Jarvis();
+
+        $receiver = new FakeReceiver();
+
+        $eventName = 'permanent.event.init';
+        $jarvis->addReceiver($eventName, [$receiver, 'onEventBroadcast']);
+        $this->assertNull($receiver->event);
+
+        $event = new SimpleEvent();
+        $permanentEvent = new PermanentEvent();
+        $jarvis->broadcast($eventName, $event);
+        $this->assertSame($event, $receiver->event);
+
+        $jarvis->broadcast($eventName, $permanentEvent);
+        $jarvis->addReceiver($eventName, [$receiver, 'onEventBroadcast']);
+        $this->assertNotSame($event, $receiver->event);
+        $this->assertSame($permanentEvent, $receiver->event);
     }
 }


### PR DESCRIPTION
This allows events tagged as `permanent` to be recalled even if the event has been dispatched on new receiver registration.
