### PR TITLE
use of ReflectionParameter 'name' attribute instead of ::getName()

### DIFF
--- a/src/Skill/DependencyInjection/ContainerProvider.php
+++ b/src/Skill/DependencyInjection/ContainerProvider.php
@@ -70,8 +70,8 @@ final class ContainerProvider implements ContainerProviderInterface
                     }
                 }
 
-                if (in_array($refParam->getName(), array_keys($rawArgs))) {
-                    $finalArgs[$refParam->getPosition()] = $rawArgs[$refParam->getName()];
+                if (in_array($refParam->name, array_keys($rawArgs))) {
+                    $finalArgs[$refParam->getPosition()] = $rawArgs[$refParam->name];
                 }
             }
 


### PR DESCRIPTION
This PR fixes minor bug reported by scrutinizer about `\ReflectionParameter::getName()` method: https://bugs.php.net/bug.php?id=61384
